### PR TITLE
HOCS-2818 Add proof-of-concept teardown script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,4 +26,29 @@ steps:
         from_secret: QUAY_ROBOT_TOKEN
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
 
+---
+
+# we're doing this as a promote to test the script
+# in reality this should normally be defined in hocs-data's .drone.yml
+
+kind: pipeline
+type: kubernetes
+name: teardown-gamma
+
+trigger:
+  event:
+    - promote
+  target:
+    - teardown
+
+steps:
+  - name: teardown gamma
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube
+      - bash ./teardown.sh
+    environment:
+      ENVIRONMENT: hocs-gamma
+      KUBE_TOKEN:
+        from_secret: hocs_toolbox_hocs_gamma
 ...

--- a/kube/destroy-info-schema.yaml
+++ b/kube/destroy-info-schema.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: destroy-info-schema
+  labels:
+    role: hocs-backend
+spec:
+  template:
+    metadata:
+      labels:
+        role: hocs-backend
+    spec:
+      containers:
+      - name: toolbox
+        image: quay.io/ukhomeofficedigital/hocs-toolbox:branch-main # TODO: make this :latest
+        command: [ "psql", "-c", "DROP SCHEMA IF EXISTS info CASCADE" ]
+        env:
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{.KUBE_NAMESPACE}}-rds
+                key: password
+          - name: PGHOST
+            valueFrom:
+              secretKeyRef:
+                name: {{.KUBE_NAMESPACE}}-rds
+                key: endpoint
+          - name: PGUSER
+            valueFrom:
+              secretKeyRef:
+                name: {{.KUBE_NAMESPACE}}-rds
+                key: username
+          - name: PGDATABASE
+            valueFrom:
+              secretKeyRef:
+                name: {{.KUBE_NAMESPACE}}-rds
+                key: db_name
+      restartPolicy: Never
+  backoffLimit: 4

--- a/kube/teardown.sh
+++ b/kube/teardown.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBE_SERVER="https://kube-api-notprod.notprod.acp.homeoffice.gov.uk"
+export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/acp-notprod.crt"
+export KUBE_NAMESPACE=${ENVIRONMENT}
+
+JOB_NAME="destroy-info-schema"
+kd -f $JOB_NAME.yaml
+kd run wait --for=condition=complete "job/$JOB_NAME"
+kd --delete -f $JOB_NAME.yaml
+kd run rollout restart "deployment/hocs-info-service"


### PR DESCRIPTION
This adds a script that creates a k8s job, runs it to drop the info
schema in the current namespace, waits for it to finish, then deletes
the job.

(The functionality to automatically delete a job in k8s is still in
alpha.)