### PR TITLE
HOCS-4537 Add helper scripts for connecting to db

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,2 @@
+echo "To connect to a database, type one of the following and hit ENTER:"
+ls db/*

--- a/db/audit
+++ b/db/audit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=${HOCS_AUDIT_PASSWORD}
+export PGUSER=${HOCS_AUDIT_USERNAME}
+export PGDATABASE=${HOCS_AUDIT_DB_NAME}
+export PGHOST=${HOCS_AUDIT_DB_HOSTNAME}
+
+psql
+
+tail -f /dev/null

--- a/db/casework
+++ b/db/casework
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=${HOCS_CASEWORK_PASSWORD}
+export PGUSER=${HOCS_CASEWORK_USERNAME}
+export PGDATABASE=${HOCS_DB_NAME}
+export PGHOST=${HOCS_DB_HOSTNAME}
+
+psql
+
+tail -f /dev/null

--- a/db/docs
+++ b/db/docs
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=${HOCS_DOCS_PASSWORD}
+export PGUSER=${HOCS_DOCS_USERNAME}
+export PGDATABASE=${HOCS_DB_NAME}
+export PGHOST=${HOCS_DB_HOSTNAME}
+
+psql
+
+tail -f /dev/null

--- a/db/info
+++ b/db/info
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=${HOCS_INFO_PASSWORD}
+export PGUSER=${HOCS_INFO_USERNAME}
+export PGDATABASE=${HOCS_DB_NAME}
+export PGHOST=${HOCS_DB_HOSTNAME}
+
+psql
+
+tail -f /dev/null

--- a/db/workflow
+++ b/db/workflow
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=${HOCS_WORKFLOW_PASSWORD}
+export PGUSER=${HOCS_WORKFLOW_USERNAME}
+export PGDATABASE=${HOCS_DB_NAME}
+export PGHOST=${HOCS_DB_HOSTNAME}
+
+psql
+
+tail -f /dev/null


### PR DESCRIPTION
This commit adds a few scripts that read the correct credentials from
the environment variables and feeds it into psql for a developer to use
to connect to one of the databases. At the moment `psql` defaults to a
default user that doesn't have any access to do anything.

Further work in this area could create some equivalent scripts for
read-only access. A cheap way to do that would be to set "SET SESSION
CHARACTERISTICS AS TRANSACTION READ ONLY;" in ~/.pgsqlrc.