### PR TITLE
Re-add accidentally uncommented lines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,8 +25,8 @@ platform:
   arch: amd64
 
 trigger:
-# branch:
-#   - main
+  branch:
+    - main
   event:
     - push
 


### PR DESCRIPTION
I commented out the "only on main" part of the pipeline while working on
my branch, but we forgot to add it back in before merging to main.