### PR TITLE
HOCS-5066 Fix db scripts not being in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ USER ${USER_ID}
 CMD /app/run.sh
 
 FROM base AS safe
-COPY scripts/safe/*.sh /app/scripts/
+COPY scripts/safe/ /app/scripts/
 RUN echo "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;" >> ~/.pgsqlrc
 
 FROM base AS dangerous
-COPY scripts/safe/*.sh /app/scripts/
-COPY scripts/dangerous/*.sh /app/scripts/
+COPY scripts/safe/ /app/scripts/
+COPY scripts/dangerous/ /app/scripts/


### PR DESCRIPTION
The previous COPY syntax copied only shell scripts. This commit changes
it to copy over whole folders, meaning that the db scripts are actually
copied into the image.