### PR TITLE
Fix secrets; add prod build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,11 +71,23 @@ steps:
     environment:
       VERSION: ${DRONE_COMMIT_SHA}-cms-migration
       KUBE_TOKEN:
-        from_secret: KUBE_TOKEN_SAFE
+        # this token only allows deploy to CMS migration namespaces:
+        from_secret: CMS_MIGRATION_NOTPROD_TOKEN
     commands:
       - cd kube
       - ./deploy.sh
     depends_on:
       - clone
 
+  - name: cs-prod-migration
+    image: quay.io/ukhomeofficedigital/kd
+    environment:
+      VERSION: ${DRONE_COMMIT_SHA}-cms-migration
+      KUBE_TOKEN:
+        from_secret: CMS_MIGRATION_PROD_TOKEN
+    commands:
+      - cd kube
+      - ./deploy.sh
+    depends_on:
+      - cs-dev-migration
 ...


### PR DESCRIPTION
This commit changes the CMS-specific dronefile to use CMS-specific
Kubernetes tokens that don't have access to any other environment, so we
can't accidentally deploy the wrong version somewhere.

As this is a manual build I've also set it to autodeploy to production
on push once the deployment to dev succeeds. Drone's manual promote
feature doesn't work well with multiple branches, and I think it's
probably easier for everyone involved if hocs-toolbox is the same
version in both dev and prod at all times.