### PR TITLE
Pass args and stdin to psql command

### DIFF
--- a/scripts/db/audit
+++ b/scripts/db/audit
@@ -5,6 +5,4 @@ export PGPASSWORD=${AUDIT_DB_RO_PASSWORD}
 export PGDATABASE=${AUDIT_DB_NAME}
 export PGHOST=${AUDIT_DB_HOST}
 
-psql
-
-tail -f /dev/null
+psql $@ <&0

--- a/scripts/db/casework
+++ b/scripts/db/casework
@@ -5,6 +5,4 @@ export PGPASSWORD=${CASEWORK_DB_RO_PASSWORD}
 export PGDATABASE=${CASEWORK_DB_NAME}
 export PGHOST=${CASEWORK_DB_HOST}
 
-psql
-
-tail -f /dev/null
+psql $@ <&0

--- a/scripts/db/docs
+++ b/scripts/db/docs
@@ -5,6 +5,4 @@ export PGPASSWORD=${DOCS_DB_RO_PASSWORD}
 export PGDATABASE=${DOCS_DB_NAME}
 export PGHOST=${DOCS_DB_HOST}
 
-psql
-
-tail -f /dev/null
+psql $@ <&0

--- a/scripts/db/info
+++ b/scripts/db/info
@@ -5,6 +5,4 @@ export PGPASSWORD=${INFO_DB_RO_PASSWORD}
 export PGDATABASE=${INFO_DB_NAME}
 export PGHOST=${INFO_DB_HOST}
 
-psql
-
-tail -f /dev/null
+psql $@ <&0

--- a/scripts/db/workflow
+++ b/scripts/db/workflow
@@ -5,6 +5,4 @@ export PGPASSWORD=${WORKFLOW_DB_RO_PASSWORD}
 export PGDATABASE=${WORKFLOW_DB_NAME}
 export PGHOST=${WORKFLOW_DB_HOST}
 
-psql
-
-tail -f /dev/null
+psql $@ <&0


### PR DESCRIPTION
This commit modifies the read-only database scripts in a way that
permits further scripting. We now pipe /dev/stdin (if it exists) into
the psql command, and any arguments to the original script get passed
through to the psql command.

For example, you can now do `./db/audit --output=output.txt` and the
output of your REPL will be sent to that file.

You can also do more advanced things now pipes are available:
```console
$ echo "SELECT uuid from case_data
> WHERE reference='ABC/123456789/10;" | db/casework -tAq
f81d4fae-7dec-11d0-a765-00a0c91e6bf6
$
```
This will open us up to being able to more easily script common
maintenance tasks. For example:

```bash
#!/bin/bash
CASE_REFERENCE=$1

if [ -z "$1" ] ; then
  echo 'Error: no case reference specified'
  echo "Usage: $0 <case reference>"
  echo "       e.g. $0 ABC/123456789/10"
  exit 64 # EX_USAGE
fi

get_case_uuid() {
  echo "SELECT uuid FROM case_data WHERE reference='$CASE_REFERENCE';" | db/casework -tAq
}

CASE_UUID=$(get_case_uuid)

echo "$CASE_UUID"
```