### PR TITLE
HOCS-4830: Revert base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/hocs-base-image
+FROM alpine:3.14
 
 USER 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.16
 
 USER 0
 


### PR DESCRIPTION
### HOCS-4830

Reverting the base image so we can test in production.

Will raise ticket in backlog to do updates for new hocs-base-image using apt-get instead of apk.