### PR TITLE
Revert to original

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM alpine:3.16
-
-USER 0
+FROM alpine:3.14
 
 ENV USER hocs
 ENV USER_ID 1000
 ENV GROUP hocs
 ENV NAME hocs-migration-toolbox
+ENV AWS_CLI_VERSION 1.16.207
 
 WORKDIR /app
 
@@ -15,23 +14,36 @@ RUN addgroup ${GROUP} &&\
     chown -R ${USER}:${GROUP} /app &&\
     mkdir -p /app/scripts
 
-RUN apk add --no-cache aws-cli bash ca-certificates curl gnupg
-RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.6.1.1-1_amd64.apk &&\
+COPY run.sh /app/
+RUN chmod a+x /app/run.sh
+
+RUN apk upgrade &&\
+    apk --no-cache update &&\
+    apk add bash &&\
+    apk add --update --no-cache curl py-pip gnupg py-setuptools ca-certificates groff less &&\
+    pip --no-cache-dir install awscli==${AWS_CLI_VERSION} &&\
+    rm -rf /var/cache/apk/* &&\
+
+# Download the desired package(s)
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.6.1.1-1_amd64.apk &&\
     curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.6.1.1-1_amd64.apk &&\
+
+# (Optional) Verify signature, if 'gpg' is missing install it using 'apk add gnupg':
     curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.6.1.1-1_amd64.sig &&\
     curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.6.1.1-1_amd64.sig &&\
     curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import - &&\
     gpg --verify msodbcsql17_17.6.1.1-1_amd64.sig msodbcsql17_17.6.1.1-1_amd64.apk &&\
     gpg --verify mssql-tools_17.6.1.1-1_amd64.sig mssql-tools_17.6.1.1-1_amd64.apk &&\
-    apk add --allow-untrusted msodbcsql17_17.6.1.1-1_amd64.apk mssql-tools_17.6.1.1-1_amd64.apk &&\
-    rm -f msodbcsql*.sig msodbcsql*.apk mssql-tools*.sig mssql-tools*.apk
 
-USER hocs
+# Install the package(s)
+    apk add --allow-untrusted msodbcsql17_17.6.1.1-1_amd64.apk mssql-tools_17.6.1.1-1_amd64.apk &&\
+
+# Remove installation files
+    rm -f msodbcsql*.sig msodbcsql*.apk mssql-tools*.sig mssql-tools*.apk
 
 # Adding SQL Server tools to $PATH
 ENV PATH=$PATH:/opt/mssql-tools/bin
-
-COPY --chown=hocs:hocs ./scripts ./
-COPY --chown=hocs:hocs run.sh ./
-
-CMD ["sh", "/app/run.sh"]
+USER ${USER_ID}
+COPY scripts/safe/*.sh /app/scripts/
+COPY scripts/safe/db/migration /app/scripts/db/
+CMD /app/run.sh


### PR DESCRIPTION
### HOCS-4830

SQL Server command line not working with newer Alpine version.
This PR is to revert back to original toolbox.